### PR TITLE
Fix dependency header

### DIFF
--- a/counsel-dash.el
+++ b/counsel-dash.el
@@ -4,7 +4,7 @@
 
 ;; Author: Nathan Kot <nk@nathankot.com>
 ;; Version: 0.1.1
-;; Package-Requires ((cl-lib "0.5") (dash "2.12.1") (dash-functional "1.2.0") (helm-dash "1.3.0") (counsel "0.8.0"))
+;; Package-Requires: ((emacs "24.4") (dash "2.12.1") (dash-functional "1.2.0") (helm-dash "1.3.0") (counsel "0.8.0"))
 ;; Keywords: dash, ivy, counsel
 ;; URL: https://github.com/nathankot/counsel-dash
 


### PR DESCRIPTION
- Add missing colon
- Remove cl-lib because it is unused.
- Specify minimum Emacs version for using advice-add which was introduced
  at Emacs 24.4.
