### PR TITLE
Use `cl-remove-duplicates` instead of `remove-duplicates` because the latter no longer exists in Emacs 27

### DIFF
--- a/counsel-dash.el
+++ b/counsel-dash.el
@@ -55,7 +55,7 @@
 (advice-add #'dash-docs-buffer-local-docsets :around
             (lambda (old-fun &rest args)
               (let ((old (apply old-fun args)))
-                (remove-duplicates (append old counsel-dash-docsets)))))
+                (cl-remove-duplicates (append old counsel-dash-docsets)))))
 
 (defun counsel-dash--collection (s &rest _)
   "Given a string S, query docsets and retrieve result."


### PR DESCRIPTION
Fix https://github.com/dash-docs-el/counsel-dash/issues/9