### PR TITLE
Require subr-x and ivy.

### DIFF
--- a/counsel-dash.el
+++ b/counsel-dash.el
@@ -17,7 +17,9 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'dash-docs)
+(require 'ivy)
 
 (defgroup counsel-dash nil
   "Search Dash docsets using ivy"


### PR DESCRIPTION
Sorry for the nit, but this package does not work properly when installed via the Guix package manager unless the `(require 'subr-x)` statement is in the file.