### PR TITLE
Remove message about counsel-dash using helm-dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Make sure `counsel-dash.el` is in your `load-path` and then:
 This is a simple wrapper around [helm-dash](https://github.com/areina/helm-dash/), of which you should check out for
 implementation details.
 
-Unfortunately [helm-dash](https://github.com/areina/helm-dash/) depends on helm, so this package also implicitly depends
-on helm - even though helm isn't really necessary. In the future, helm-dash may be decoupled into a separate library
-that provides dash capabilities only. At that point we will switch over to the new library - the API will remain unchanged.
-
 ## Configuration
 
 You'll find most of the available functions and configuration variables are

--- a/counsel-dash.el
+++ b/counsel-dash.el
@@ -27,7 +27,7 @@
   :group 'ivy)
 
 ; Aliases are used so that we can provide a common interface, irrespective of
-; any library changes in the future (e.g if helm-dash de-couples itself into two libraries.)
+; any library changes in the future.
 
 (defvaralias 'counsel-dash-docsets-path 'dash-docs-docsets-path)
 (defvaralias 'counsel-dash-docsets-url 'dash-docs-docsets-url)


### PR DESCRIPTION
It looks like that was fixed in #8 , and a quick search of the package code turns up only one match for `helm`, in a comment.